### PR TITLE
feat(*): start the process of getting Interactive connections going to prod

### DIFF
--- a/bin/miix
+++ b/bin/miix
@@ -35,6 +35,10 @@ const yargs = require('yargs')
     'Boots up an interactive development server.',
     argv =>
       argv
+        .option('connect-channel', {
+          describe: 'Channel to connect to in the editor. Defaults to your own.',
+          default: process.env.MIIX_CONNECT_CHANNEL,
+        })
         .usage('miix serve [-- <webpack-dev-server args>]')
         .example('miix serve', 'Boot a server on http://localhost:8080')
         .example(
@@ -43,7 +47,13 @@ const yargs = require('yargs')
         ),
     execute
   )
-  .command('debug-metadata', 'Displays project metadata', {}, execute)
+  .command(
+    'pack',
+    'Creates a packaged version of your controls as uploaded in `miix publish`. Useful for debugging.',
+    {},
+    execute
+  )
+  .command('debug-metadata', false, {}, execute)
   .strict()
   .help()
   .demandCommand().argv;

--- a/package.json
+++ b/package.json
@@ -53,8 +53,10 @@
     "@types/joi": "^10.4.1",
     "@types/js-yaml": "^3.9.0",
     "@types/json5": "0.0.29",
+    "@types/lodash": "^4.14.74",
     "@types/mocha": "^2.2.41",
     "@types/node-fetch": "^1.6.7",
+    "@types/ora": "^1.3.1",
     "@types/sinon": "^2.3.3",
     "@types/sinon-chai": "^2.7.28",
     "@types/yargs": "^8.0.2",
@@ -94,8 +96,11 @@
     "express": "^4.15.4",
     "joi": "^10.6.0",
     "js-yaml": "^3.9.1",
+    "lodash": "^4.17.4",
     "node-fetch": "^1.7.2",
+    "ora": "^1.3.0",
     "parse5": "^3.0.2",
+    "tar": "^4.0.1",
     "yargs": "^8.0.2"
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,4 +1,3 @@
-import * as chalk from 'chalk';
 import { unlinkSync } from 'fs';
 
 import { Profile } from '../profile';
@@ -11,6 +10,6 @@ export default async function(options: IGlobalOptions): Promise<void> {
   } catch (e) {
     /* ignored */
   }
-  await new Profile(options.profile).tokens();
-  writer.write(chalk.green('Logged in successfully!'));
+  await new Profile(options.profile).grant();
+  writer.write('Logged in successfully!');
 }

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,4 +1,3 @@
-import * as chalk from 'chalk';
 import { unlinkSync } from 'fs';
 
 import writer from '../writer';
@@ -11,5 +10,5 @@ export default async function(options: IGlobalOptions): Promise<void> {
     /* ignored */
   }
 
-  writer.write(chalk.green('Logged out successfully.'));
+  writer.write('Logged out successfully.');
 }

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -1,0 +1,14 @@
+import * as chalk from 'chalk';
+import * as ora from 'ora';
+
+import { Bundler } from '../publish/bundler';
+import { IGlobalOptions } from './options';
+
+export default async function(options: IGlobalOptions): Promise<void> {
+  const spinner = ora('Starting...').start();
+  const file = await new Bundler(options.project).bundle(progress => {
+    spinner.text = progress;
+  });
+
+  spinner.succeed(`Bundle created in ${chalk.green(file)}`);
+}

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -7,6 +7,7 @@ import { Profile } from '../profile';
 import { never } from '../util';
 import { createApp } from '../webpack/dev-server';
 import { devEnvironmentVar } from '../webpack/plugin';
+import { IDevEnvironment } from '../webpack/typings';
 import { IGlobalOptions } from './options';
 
 function defaultArgs(original: string[], defaults: { [key: string]: string | boolean }): string[] {
@@ -21,10 +22,14 @@ function defaultArgs(original: string[], defaults: { [key: string]: string | boo
   return original;
 }
 
-export default async function(options: IGlobalOptions): Promise<void> {
+export interface IServeOptions extends IGlobalOptions {
+  connectChannel: number;
+}
+
+export default async function(options: IServeOptions): Promise<void> {
   const argDelimiter = process.argv.indexOf('--');
   const profile = new Profile(options.profile);
-  const server = createServer(createApp(profile)).listen(0);
+  const server = createServer(createApp(profile, options.connectChannel)).listen(0);
   let args = argDelimiter > -1 ? process.argv.slice(argDelimiter + 1) : [];
 
   args = defaultArgs(args, {
@@ -41,9 +46,11 @@ export default async function(options: IGlobalOptions): Promise<void> {
       cwd: process.cwd(),
       env: {
         ...process.env,
-        [devEnvironmentVar]: JSON.stringify({
-          address: `127.0.0.1:${server.address().port}`,
-        }),
+        [devEnvironmentVar]: JSON.stringify(
+          <IDevEnvironment>{
+            address: `127.0.0.1:${server.address().port}`,
+          },
+        ),
       },
     });
 

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,11 +1,16 @@
 import { Profile } from '../profile';
-import { Fetcher } from '../util';
 import writer from '../writer';
 import { IGlobalOptions } from './options';
 
 export default async function(options: IGlobalOptions) {
-  const tokens = await new Profile(options.profile).tokens();
-  const user = await new Fetcher().with(tokens).json('get', '/users/current?fields=id,username');
-  const data = await user.json();
-  writer.write(`You are logged in as ${data.username} (userID=${data.id})`);
+  const profile = new Profile(options.profile);
+  if (!await profile.hasAuthenticated()) {
+    writer.write('You are not logged in! Run `miix login` to authenticated');
+    return;
+  }
+
+  const data = await profile.user();
+  writer.write(
+    `You are logged in as ${data.username} (userID=${data.id}, channelID=${data.channel})`,
+  );
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,8 +10,8 @@ export class ShortCodeError extends Error {}
  * from Mixer.
  */
 export class ShortCodeUnexpectedError extends ShortCodeError {
-  constructor(public readonly res: Response) {
-    super(`Unexpected status code ${res.status} ${res.statusText} from ${res.url}`);
+  constructor(public readonly res: Response, public readonly text: string) {
+    super(`Unexpected status code ${res.status} ${res.statusText} from ${res.url}: ${text}`);
   }
 }
 
@@ -38,3 +38,15 @@ export class ShortCodeAccessDeniedError extends ShortCodeError {
  * MixerPluginError is thrown when there's an error in the webpack MixerPlugin.
  */
 export class MixerPluginError extends Error {}
+
+/**
+ * A PackageIntegrityError is thrown during the bundling process if something
+ * is amiss in the build process.
+ */
+export class PackageIntegrityError extends Error {}
+
+/**
+ * A WebpackBundlerError is thrown during the bundling process if
+ * webpack throws an error.
+ */
+export class WebpackBundlerError extends Error {}

--- a/src/metadata/metadata.ts
+++ b/src/metadata/metadata.ts
@@ -8,6 +8,8 @@ import { IPackageConfig } from './package';
 // TypeScript will enforce most of this, but some parts come from the
 // package.json and not all consumers may be using TypeScript or strict typing.
 const packageSchema = Joi.object({
+  name: Joi.string().required(),
+  version: Joi.string().required(),
   display: Joi.object({
     mode: Joi.valid('fixed-grid', 'flex').required(),
   }),
@@ -41,6 +43,8 @@ export async function createPackage(dir: string): Promise<IPackageConfig> {
   const staticData = await new MetadataExtractor().compile(dir);
 
   const packaged = {
+    name: packageJson.name,
+    version: packageJson.version,
     ...packageJson.interactive,
     ...staticData,
   };

--- a/src/metadata/package.ts
+++ b/src/metadata/package.ts
@@ -6,6 +6,8 @@ import { IControlOptions, ISceneOptions } from './decoration';
  * controls boot.
  */
 export interface IPackageConfig {
+  name: string;
+  version: string;
   display: {
     mode: 'fixed-grid' | 'flex';
   };

--- a/src/participant/participant.ts
+++ b/src/participant/participant.ts
@@ -1,0 +1,165 @@
+import { EventEmitter } from 'eventemitter3';
+import { stringify } from 'querystring';
+
+import { RPC, RPCError } from '../stdlib/rpc';
+import { ErrorCode, IStateDump } from '../stdlib/typings';
+
+/**
+ * This is file contains a websocket implementation to coordinate messaging
+ * between the Interactive iframe and the Interactive service.
+ */
+
+const enum State {
+  Loading,
+  Ready,
+}
+
+/**
+ * IConnectionOptions is passed into Participant.connect()
+ */
+export interface IConnectionOptions {
+  socketAddress: string;
+  contentAddress: string;
+  xAuthUser?: object;
+}
+
+/**
+ * Participant is a bridge between the Interactive service and an iframe that
+ * shows custom controls. It proxies calls between them and emits events
+ * when states change.
+ */
+export class Participant extends EventEmitter {
+  /**
+   * Interactive protocol version this participant implements.
+   */
+  public static readonly protocolVersion = '2.0';
+
+  /**
+   * Websocket connecte
+   */
+  private websocket: WebSocket;
+
+  /**
+   * RPC wrapper around the controls.
+   */
+  private rpc: RPC;
+
+  /**
+   * Buffer of packets from Interactive to replace once the controls load.
+   * As soon as we connect to interactive it'll send the initial state
+   * messages, but there's a good chance we won't have loaded the controls
+   * by that time, so buffer 'em until the controls say they're ready.
+   */
+  private replayBuffer: string[] = [];
+
+  /**
+   * Controls state.
+   */
+  private state = State.Loading;
+
+  constructor(private readonly frame: HTMLIFrameElement) {
+    super();
+    this.rpc = new RPC(frame.contentWindow);
+  }
+
+  /**
+   * Creates a connection to the given Interactive address.
+   */
+  public connect(options: IConnectionOptions): this {
+    const qs = stringify({
+      // cache bust the iframe to ensure that it reloads
+      // whenever we get a new connection.
+      bustCache: Date.now(),
+      'x-auth-user': options.xAuthUser ? JSON.stringify(options.xAuthUser) : undefined,
+    });
+
+    const ws = (this.websocket = new WebSocket(`${options.socketAddress}&${qs}`));
+    this.frame.src = `${options.contentAddress}&${qs}`;
+
+    this.rpc.expose('sendInteractivePacket', data => {
+      ws.send({ ...data, discard: true });
+    });
+
+    this.rpc.expose('controlsReady', () => {
+      this.replayBuffer.forEach(p => {
+        this.sendInteractive(p);
+      });
+      this.replayBuffer = [];
+      this.state = State.Ready;
+      this.emit('loaded');
+    });
+
+    ws.addEventListener('message', data => {
+      if (this.state !== State.Ready) {
+        this.replayBuffer.push(data.data);
+      } else {
+        this.sendInteractive(data.data);
+      }
+    });
+
+    ws.addEventListener('close', ev => {
+      this.emit('close', ev.code, ev);
+    });
+
+    ws.addEventListener('error', ev => {
+      this.emit('close', -1, ev);
+    });
+
+    return this;
+  }
+
+  public dumpState(): Promise<IStateDump | undefined> {
+    return this.rpc.call<IStateDump>('dumpState', {}, true).catch(err => {
+      if (err instanceof RPCError && err.code === ErrorCode.AppBadMethod) {
+        return undefined; // controls don't expose dumpState, sad but we'll hide our sadness
+      }
+
+      throw new err();
+    });
+  }
+
+  /**
+   * Closes the participant connection and frees resources.
+   */
+  public destroy() {
+    this.rpc.destroy();
+
+    try {
+      this.websocket.close();
+    } catch (_e) {
+      // Ignored. Sockets can be fussy if they're closed at
+      // the wrong time but it doesn't cause issues.
+    }
+  }
+
+  /**
+   * A close event is emitted, with the error code, if we fail to connect
+   * to Interactive or the connection is lost, a code of -1 will be given.
+   */
+  public on(event: 'close', handler: (code: number, ev: Event) => void): this;
+
+  /**
+   * Transmit is fired whenever we proxy an event from the Interactive
+   * socket to the controls.
+   */
+  public on(event: 'transmit', handler: (data: object) => void): this;
+
+  /**
+   * Loaded is fired when the contained iframe loads.
+   */
+  public on(event: 'loaded', handler: () => void): this;
+  public on(event: string, handler: (...args: any[]) => void): this {
+    super.on(event, handler);
+    return this;
+  }
+
+  /**
+   * sendInteractive broadcasts the interactive payload down to the controls,
+   * and emits a `transmit` event.
+   */
+  private sendInteractive(data: string) {
+    const parsed = JSON.parse(data);
+    this.rpc.call('recieveInteractivePacket', parsed, false);
+    this.emit('transmit', parsed);
+  }
+}

--- a/src/participant/tslint.json
+++ b/src/participant/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tslint.json",
+  "rules": {
+    "promise-function-async": false
+  }
+}

--- a/src/publish/bundler.ts
+++ b/src/publish/bundler.ts
@@ -1,0 +1,106 @@
+import { fork } from 'child_process';
+import * as path from 'path';
+
+import { PackageIntegrityError, WebpackBundlerError } from '../errors';
+import { createPackage } from '../metadata/metadata';
+import { getPackageExecutable } from '../npm';
+import { exists, readDir } from '../util';
+
+const tar = require('tar'); // typings are pretty bad for this module.
+
+/**
+ * Bundler packages up controls from a project directory into a tarball
+ * that can be uploaded to Mixer.
+ */
+export class Bundler {
+  constructor(private readonly projectDir: string) {}
+
+  public async bundle(
+    progressReporter: (message: string) => void = () => undefined,
+  ): Promise<string> {
+    progressReporter('Reading control metadata');
+    const packaged = await createPackage(this.projectDir);
+
+    progressReporter('Running webpack bundler');
+    const filename = path.join(process.cwd(), `${packaged.name}.tar.gz`);
+    await this.runWebpack();
+
+    progressReporter('Verifying basic integrity');
+    const outputDir = this.getOutputPath();
+    await this.verifyIntegrity(outputDir);
+
+    progressReporter('Compressing files');
+    await this.createTarball(outputDir, filename);
+
+    return filename;
+  }
+
+  /**
+   * Throws an PackageIntegrityError if there are any obvious problems with
+   * the bundler output.
+   */
+  private async verifyIntegrity(output: string): Promise<void> {
+    const home = path.join(output, 'index.html');
+    if (!await exists(home)) {
+      throw new PackageIntegrityError(
+        `An index.html is missing in your project output (${home} should exist)`,
+      );
+    }
+  }
+
+  /**
+   * Compresses the output dir into the target tarball.
+   */
+  private async createTarball(output: string, target: string): Promise<void> {
+    const files = await readDir(output);
+    await tar.create(
+      {
+        file: target,
+        gzip: { level: 9 },
+        cwd: output,
+      },
+      files,
+    );
+  }
+
+  /**
+   * Returns the webpack output path.
+   */
+  private getOutputPath(): string {
+    // tslint:disable-next-line
+    return require(path.join(this.projectDir, 'webpack.config.js')).output.path;
+  }
+
+  /**
+   * Runs webpack to create a production bundle.
+   */
+  private async runWebpack(): Promise<void> {
+    const wds = await getPackageExecutable(path.join(this.projectDir, 'node_modules', 'webpack'));
+
+    const child = fork(wds, ['--display=minimal'], {
+      cwd: process.cwd(),
+      env: { ...process.env, ENV: 'production' },
+      silent: true,
+    });
+
+    const stdAll: (string | Buffer)[] = [];
+    child.stdout.on('data', data => {
+      stdAll.push(data);
+    });
+    child.stderr.on('data', data => {
+      stdAll.push(data);
+    });
+
+    await new Promise(resolve => {
+      child.on('close', code => {
+        if (code === 0) {
+          resolve();
+          return;
+        }
+
+        const output = Buffer.concat(stdAll.map(s => (typeof s === 'string' ? Buffer.from(s) : s)));
+        throw new WebpackBundlerError(output.toString('utf8'));
+      });
+    });
+  }
+}

--- a/src/shortcode.ts
+++ b/src/shortcode.ts
@@ -100,7 +100,7 @@ export class OAuthShortCode {
       case 404:
         throw new ShortCodeExpireError();
       default:
-        throw new ShortCodeUnexpectedError(res);
+        throw new ShortCodeUnexpectedError(res, await res.text());
     }
 
     await Promise.race([
@@ -121,7 +121,7 @@ export class OAuthShortCode {
     });
 
     if (res.status >= 300) {
-      throw new ShortCodeUnexpectedError(res);
+      throw new ShortCodeUnexpectedError(res, await res.text());
     }
 
     return OAuthTokens.fromTokenResponse(await res.json(), this.scopes);
@@ -193,7 +193,7 @@ export class OAuthClient {
     });
 
     if (results.status >= 300) {
-      throw new ShortCodeUnexpectedError(results);
+      throw new ShortCodeUnexpectedError(results, await results.text());
     }
 
     const json: IShortcodeCreateResponse = await results.json();
@@ -210,7 +210,7 @@ export class OAuthClient {
     });
 
     if (res.status >= 300) {
-      throw new ShortCodeUnexpectedError(res);
+      throw new ShortCodeUnexpectedError(res, await res.text());
     }
 
     return OAuthTokens.fromTokenResponse(await res.json(), tokens.data.scopes);

--- a/src/stdlib/mixer.ts
+++ b/src/stdlib/mixer.ts
@@ -14,6 +14,7 @@ import {
   ISceneCreate,
   ISceneDelete,
   ISceneUpdate,
+  IStateDump,
   IVideoPositionOptions,
 } from './typings';
 
@@ -37,6 +38,14 @@ export class Socket extends EventEmitter {
     rpc.expose('recieveInteractivePacket', (data: IInteractiveRPCMethod<any>) => {
       this.emit(data.method, data.params);
     });
+  }
+
+  /**
+   * Sets the handler to use when the editor requests a dump of the current
+   * controls state.
+   */
+  public dumpHandler(fn: () => IStateDump) {
+    rpc.expose('dumpState', fn);
   }
 
   public on(event: 'onParticipantJoin', handler: (ev: IParticipantUpdate) => void): this;
@@ -71,7 +80,7 @@ export class Socket extends EventEmitter {
         method,
         params,
       },
-      waitForReply,
+      <any>waitForReply,
     );
     if (!reply) {
       return;

--- a/src/stdlib/typings.ts
+++ b/src/stdlib/typings.ts
@@ -377,3 +377,48 @@ export interface ISettings {
    */
   placesVideo: boolean;
 }
+
+/**
+ * IStateDump is a dump of the raw object tree. The Mixer.socket has an
+ * `onStateDump` handler which should be attached to; the editor will use
+ * this during runtime for debugging.
+ */
+export interface IStateDump {
+  scenes: IScene[];
+  groups: IGroup[];
+  participant: IParticipant;
+}
+
+/**
+ * Enumeration of Interactive error codes. More docs and descriptions can be found in:
+ * {@link https://dev.mixer.com/reference/interactive/protocol/protocol.pdf}
+ */
+export enum ErrorCode {
+  CloseUnknown = 1011,
+  CloseRestarting = 1012,
+
+  AppBadJson = 4000,
+  AppBadCompression,
+  AppBadPacketType,
+  AppBadMethod,
+  AppBadArgs,
+  AppBadEtag,
+  AppExpiredTransaction,
+  AppNotEnoughSparks,
+  AppUnknownGroup,
+  AppGroupExists,
+  AppUnknownScene,
+  AppSceneExists,
+  AppUnknownControl,
+  AppControlExists,
+  AppUnknownControlType,
+  AppUnknownParticipant,
+  AppSessionClosing,
+  AppOutOfMemory,
+  AppCannotDeleteDefault,
+  AppCannotAuthenticate,
+  AppNoInteractiveVersion,
+  AppExistingInteractiveSession,
+  AppChannelNotOnline,
+  AppBadUserInput = 4999,
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,6 +26,21 @@ export async function exists(file: string): Promise<boolean> {
 }
 
 /**
+ * Promisified fs.readDir
+ */
+export async function readDir(dir: string): Promise<string[]> {
+  return new Promise<string[]>((resolve, reject) => {
+    fs.readdir(dir, (err, results) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(results);
+      }
+    });
+  });
+}
+
+/**
  * Returns a promise that resolves after the given duration.
  */
 export async function delay(duration: number): Promise<void> {
@@ -68,12 +83,19 @@ export interface IRequester {
 }
 
 /**
+ * Returns a path to the Mixer API.
+ */
+export function api(): string {
+  return process.env.MIIX_API_HOST || 'https://mixer.com';
+}
+
+/**
  * Fetcher is a concrete, node-fetch-based implementation of IRequester.
  */
 export class Fetcher implements IRequester {
   constructor(
     private readonly policies: IFetchPolicy[] = [],
-    private readonly host: string = 'https://mixer.com/api/v1',
+    private readonly host: string = `${api()}/api/v1`,
     private readonly fetch: typeof nodeFetch = nodeFetch,
   ) {}
 

--- a/src/webpack/dev-server.ts
+++ b/src/webpack/dev-server.ts
@@ -1,17 +1,100 @@
 import * as express from 'express';
+import { Fetcher } from '../util';
 
-import { Profile } from '../profile';
+import { GrantCancelledError, Profile } from '../profile';
+
+function route(handler: (req: express.Request, res: express.Response) => Promise<object | void>) {
+  return (req: express.Request, res: express.Response) => {
+    Promise.resolve(handler(req, res))
+      .then(data => {
+        if (res.headersSent) {
+          return;
+        }
+
+        if (!data) {
+          res.status(204);
+          return;
+        }
+
+        res.json(data);
+      })
+      .catch(err => res.status(500).send(err.stack || err.message || err));
+  };
+}
 
 /**
  * This file contains the parent dev server run using `miix serve`. This has
  * endpoints for saving environment/profile settings as well as making calls
  * out to the Mixer API on behalf of the logged in user.
  */
-
-export function createApp(_profile: Profile): express.Express {
+export function createApp(profile: Profile, connectChannel: number): express.Express {
   const app = express();
 
-  app.get('/', (_req, res) => res.send('hello world!'));
+  app.use((_req, res, next) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', '*');
+    res.setHeader('Access-Control-Allow-Headers', '*');
+    next();
+  });
+
+  app.get(
+    '/connect-participant',
+    route(async (_req, res) => {
+      if (!await profile.hasAuthenticated()) {
+        res.status(401).send();
+        return;
+      }
+
+      const udata = await profile.user();
+      const joinRes = await new Fetcher()
+        .with(await profile.tokens())
+        .json('get', `/interactive/${connectChannel || udata.channel}`);
+
+      if (joinRes.status === 400) {
+        res.status(409).send(); // remap
+        return;
+      }
+
+      if (joinRes.status !== 200) {
+        throw new Error(
+          `Unexpected status code ${joinRes.status} from ${joinRes.url}: ${await joinRes.text()}`,
+        );
+      }
+
+      return await joinRes.json();
+    }),
+  );
+
+  let grantingCode: string | undefined;
+  app.get(
+    '/login',
+    route(async () => {
+      if (await profile.hasAuthenticated()) {
+        return await profile.user();
+      }
+      if (grantingCode) {
+        return { code: grantingCode };
+      }
+
+      return new Promise(resolve => {
+        profile
+          .grant({
+            prompt: code => {
+              grantingCode = code;
+              resolve(code);
+            },
+            isCancelled: () => grantingCode !== undefined, // don't retry forever
+          })
+          .catch(err => {
+            if (err instanceof GrantCancelledError) {
+              grantingCode = undefined;
+            } else {
+              throw err;
+            }
+          });
+      }).then(code => ({ code }));
+    }),
+  );
 
   return app;
 }

--- a/src/webpack/editor/editor.module.ts
+++ b/src/webpack/editor/editor.module.ts
@@ -4,9 +4,11 @@ import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import {
   MdButtonModule,
+  MdDialogModule,
   MdIconModule,
   MdInputModule,
   MdSelectModule,
+  MdSnackBarModule,
   MdTooltipModule,
 } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
@@ -17,6 +19,7 @@ import { StoreModule } from '@ngrx/store';
 import { CodeComponent } from './code/code.component';
 import { FrameComponent } from './frame/frame.component';
 import { HostComponent } from './host/host.component';
+import { LaunchDialogComponent } from './launch-dialog/launch-dialog.component';
 import { CodeNavComponent } from './nav/code-nav.component';
 import { NavComponent } from './nav/nav.component';
 import { metaReducers, ProjectService, reducers } from './redux/project';
@@ -31,16 +34,26 @@ require('../../../static/editor/style.scss');
     BrowserAnimationsModule,
     BrowserModule,
     CommonModule,
-    HttpModule,
     FormsModule,
+    HttpModule,
     MdButtonModule,
+    MdDialogModule,
     MdIconModule,
     MdInputModule,
     MdSelectModule,
+    MdSnackBarModule,
     MdTooltipModule,
     StoreModule.forRoot(reducers, { metaReducers }),
   ],
-  declarations: [CodeComponent, CodeNavComponent, FrameComponent, HostComponent, NavComponent],
+  declarations: [
+    CodeComponent,
+    CodeNavComponent,
+    FrameComponent,
+    HostComponent,
+    LaunchDialogComponent,
+    NavComponent,
+  ],
+  entryComponents: [LaunchDialogComponent],
   providers: [ProjectService],
   bootstrap: [HostComponent],
 })

--- a/src/webpack/editor/frame/frame.component.html
+++ b/src/webpack/editor/frame/frame.component.html
@@ -29,7 +29,7 @@
       [style.width.px]="(sync.videoSize() | async)?.width"
       [style.height.px]="(sync.videoSize() | async)?.height">
     </div>
-    <iframe src="/" frameborder="0" #iframe></iframe>
+    <iframe frameborder="0" #iframe></iframe>
   </div>
 </div>
 

--- a/src/webpack/editor/frame/frame.component.ts
+++ b/src/webpack/editor/frame/frame.component.ts
@@ -5,7 +5,6 @@ import {
   Component,
   ElementRef,
   OnDestroy,
-  ViewChild,
 } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
 import { Store } from '@ngrx/store';
@@ -24,7 +23,6 @@ import '../util/takeUntilDestroyed';
 import { IFrameState } from '../redux/frame';
 import { IProject, ProjectService } from '../redux/project';
 import { devices, IBlock, IDevice } from './devices';
-import { StateSyncService } from './state-sync.service';
 
 /**
  * One random background is chosen eac
@@ -44,7 +42,6 @@ const backgrounds = [
   templateUrl: './frame.component.html',
   styleUrls: ['./frame.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [StateSyncService],
 })
 export class FrameComponent implements AfterContentInit, OnDestroy {
   /**
@@ -80,18 +77,12 @@ export class FrameComponent implements AfterContentInit, OnDestroy {
    */
   public device: Observable<IDevice> = this.state.map(s => devices[s.chosenDevice]);
 
-  /**
-   * The nested iframe containing the control.
-   */
-  @ViewChild('iframe') public iframe: ElementRef;
-
   constructor(
-    private el: ElementRef,
-    private cdRef: ChangeDetectorRef,
-    private project: ProjectService,
-    private store: Store<IProject>,
-    private sanitizer: DomSanitizer,
-    public sync: StateSyncService,
+    private readonly el: ElementRef,
+    private readonly cdRef: ChangeDetectorRef,
+    private readonly project: ProjectService,
+    private readonly store: Store<IProject>,
+    private readonly sanitizer: DomSanitizer,
   ) {}
 
   public ngAfterContentInit() {
@@ -109,8 +100,6 @@ export class FrameComponent implements AfterContentInit, OnDestroy {
       .subscribe(state => {
         this.refreshBlocks(state);
       });
-
-    this.sync.bind((<HTMLIFrameElement>this.iframe.nativeElement).contentWindow);
   }
 
   public ngOnDestroy() {

--- a/src/webpack/editor/frame/local-controls.component.ts
+++ b/src/webpack/editor/frame/local-controls.component.ts
@@ -1,0 +1,31 @@
+import {
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  ViewChild,
+} from '@angular/core';
+
+import { LocalStateSyncService } from './local-state-sync.service';
+
+/**
+ * The FrameComponent hosts the frame containing the developer's controls.
+ */
+@Component({
+  selector: 'editor-local-controls',
+  template: '<iframe frameborder="0" src="/"></iframe>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [LocalStateSyncService],
+})
+export class FrameComponent implements AfterContentInit {
+  /**
+   * The nested iframe containing the control.
+   */
+  @ViewChild('iframe') public iframe: ElementRef;
+
+  constructor(public sync: LocalStateSyncService) {}
+
+  public ngAfterContentInit() {
+    this.sync.bind(<HTMLIFrameElement>this.iframe.nativeElement);
+  }
+}

--- a/src/webpack/editor/frame/remote-controls.component.ts
+++ b/src/webpack/editor/frame/remote-controls.component.ts
@@ -1,0 +1,114 @@
+import {
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Input,
+  OnDestroy,
+  ViewChild,
+} from '@angular/core';
+import { MdSnackBar } from '@angular/material';
+import { Store } from '@ngrx/store';
+import * as json5 from 'json5';
+import { throttle } from 'lodash';
+import { IInteractiveJoin } from '../redux/connect';
+
+import { Participant } from '../../../participant/participant';
+import { ErrorCode } from '../../../stdlib/typings';
+import { IProject, ProjectService } from '../redux/project';
+
+/**
+ * The RemoteControlsComponent hosts the frame containing remote Interactive
+ * controls.
+ */
+@Component({
+  selector: 'editor-local-controls',
+  template: '<iframe frameborder="0" src="/"></iframe>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RemoteControlsComponent implements AfterContentInit, OnDestroy {
+  /**
+   * Details on where to join Interactive.
+   */
+  @Input() public address: IInteractiveJoin;
+
+  /**
+   * The nested iframe containing the control.
+   */
+  @ViewChild('iframe') public iframe: ElementRef;
+
+  /**
+   * Participant socket interface.
+   */
+  private participant: Participant;
+
+  /**
+   * Called whenever a packet is transmitted over the Interactive connection.
+   */
+  private onTransmit = throttle(() => {
+    this.participant
+      .dumpState()
+      .then(dump => {
+        if (dump) {
+          this.project.setControlsState(dump);
+        }
+      })
+      .catch(() => undefined); // ignored
+  });
+
+  constructor(
+    private readonly store: Store<IProject>,
+    private readonly snackRef: MdSnackBar,
+    private readonly project: ProjectService,
+  ) {}
+
+  public ngAfterContentInit() {
+    this.store.map(state => state.code.participant).take(1).subscribe(participant => {
+      const xAuthUser = { ID: 1, Username: 'tester' };
+      try {
+        const parsed = json5.parse(participant.join('\n'));
+        xAuthUser.ID = parsed.userID;
+        xAuthUser.Username = parsed.username;
+      } catch (_e) {
+        // ignored. We try to parse it to be nice but no biggie if we can't
+      }
+
+      const p = new Participant(<HTMLIFrameElement>this.iframe.nativeElement).connect({
+        xAuthUser,
+        socketAddress: this.address.address,
+        contentAddress: this.address.contentAddress,
+      });
+
+      p.on('loaded', () => {
+        this.afterConnect();
+      });
+      p.on('close', code => {
+        this.onClose(code);
+      });
+      p.on('transmit', this.onTransmit);
+      this.participant = p;
+    });
+  }
+
+  public ngOnDestroy() {
+    this.participant.destroy();
+  }
+
+  /**
+   * Called when the participant socket closes, for any reason.
+   */
+  public onClose(code: number) {
+    this.snackRef.open(
+      `The interactive connection was closed with code ${code}: ${ErrorCode[code] || 'UNKNOWN'}`,
+    );
+
+    this.project.disconnectControls();
+  }
+
+  /**
+   * Called after the pariticipant socket opens.
+   */
+  private afterConnect() {
+    this.snackRef.open('Connected! Press ESC to exit Interactive.');
+  }
+}

--- a/src/webpack/editor/launch-dialog/launch-dialog.component.html
+++ b/src/webpack/editor/launch-dialog/launch-dialog.component.html
@@ -1,0 +1,20 @@
+<div class="loader"></div>
+
+<div class="status" *ngIf="(state | async) === State.AwaitingLogin">
+  <ng-container *ngIf="(code | async) !== null">
+      Go to <a [href]="codeUrl | async" target="_blank">mixer.com/go</a> to log in!
+      <small>You only have to do this once.</small>
+  </ng-container>
+  <ng-container *ngIf="(code | async) === null">
+      Getting a login code<span class="dots">{{ dots | async }}</span>
+  </ng-container>
+</div>
+
+<div class="status" *ngIf="(state | async) === State.Connecting">
+  Connecting to your channel<span class="dots">{{ dots | async }}</span>
+</div>
+
+<div class="status" *ngIf="(state | async) === State.AwaitingGameClient">
+  Waiting for your game client<span class="dots">{{ dots | async }}</span>
+  <small>Users can only connect to Interactive while your game client is running.</small>
+</div>

--- a/src/webpack/editor/launch-dialog/launch-dialog.component.scss
+++ b/src/webpack/editor/launch-dialog/launch-dialog.component.scss
@@ -1,0 +1,34 @@
+@import '../../../../static/editor/declarations';
+
+@keyframes loader-spin {
+  0%   { transform: rotate(0deg) }
+  100% { transform: rotate(360deg) }
+}
+
+.loader {
+  width: $dimension-loader-size;
+  height: $dimension-loader-size;
+  border-radius: 50%;
+  border: $dimension-loader-border solid rgba(#fff, 0.3);
+  border-left-color: #fff;
+  margin: $dimension-gutter-xl auto;
+  animation: loader-spin 1s infinite linear;
+}
+
+.status {
+  font-weight: 300;
+  text-align: center;
+  font-size: 1.3em;
+
+  small {
+    display: block;
+    font-size: 0.7em;
+    margin-top: 0.5em;
+  }
+}
+
+.dots {
+  display: inline-block;
+  width: 1em;
+  text-align: left;
+}

--- a/src/webpack/editor/launch-dialog/launch-dialog.component.ts
+++ b/src/webpack/editor/launch-dialog/launch-dialog.component.ts
@@ -1,0 +1,139 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { Http, Response } from '@angular/http';
+import { MdDialogRef, MdSnackBar } from '@angular/material';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Observable } from 'rxjs/Observable';
+
+import 'rxjs/add/observable/interval';
+import 'rxjs/add/operator/publishReplay';
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/takeUntil';
+
+import { IInteractiveJoin } from '../redux/connect';
+import { apiUrl } from '../util/env';
+import { MemorizingSubject } from '../util/memorizingSubject';
+
+export enum State {
+  Connecting,
+  AwaitingLogin,
+  AwaitingGameClient,
+}
+
+/**
+ * The Launch Dialog prompts the user to log in, and connect to Interactive
+ * for them. It calls back with connection details, or undefined if the dialog
+ * was dismissed beforehand.
+ */
+@Component({
+  selector: 'launch-dialog',
+  templateUrl: './launch-dialog.component.html',
+  styleUrls: ['./launch-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LaunchDialogComponent implements OnInit {
+  /**
+   * Exposed State enum for the template to consume.
+   */
+  public State = State; // tslint:disable-line
+
+  /**
+   * Curre state of the component.
+   */
+  public state = new BehaviorSubject(State.Connecting);
+
+  /**
+   * code is the shortcode to display to the user that they need to enter
+   * on mixer.com/go in order to start login.
+   */
+  public code = new MemorizingSubject<string>();
+
+  /**
+   * codeUrl is the full Mixer URL the user should go to
+   */
+  public codeUrl: Observable<SafeUrl> = this.code.map(code =>
+    this.sanitizer.bypassSecurityTrustUrl(`https://mixer.com/go?code=${code}`),
+  );
+
+  /**
+   * Dots used to subtly indicate progress.
+   */
+  public dots = Observable.interval(250)
+    .map(x => {
+      let n = '.';
+      while (n.length < x % 3 + 1) {
+        n += '.';
+      }
+      return n;
+    })
+    .publishReplay(1)
+    .refCount();
+
+  constructor(
+    private readonly http: Http,
+    private readonly dialogRef: MdDialogRef<IInteractiveJoin>,
+    private readonly snackRef: MdSnackBar,
+    private readonly sanitizer: DomSanitizer,
+  ) {}
+
+  public ngOnInit() {
+    setTimeout(() => {
+      this.connect();
+    }, 1000);
+  }
+
+  /**
+   * Attempts to create a connection to Interactive. Closes the dialog
+   * when it successfully does so.
+   */
+  public connect() {
+    this.http.get(apiUrl('connect-participant')).subscribe(
+      res => {
+        this.dialogRef.close(res.json());
+      },
+      (err: Response) => {
+        switch (err.status) {
+          case 401:
+            this.login();
+            break;
+          case 409:
+            this.state.next(State.AwaitingGameClient);
+            Observable.interval(5000)
+              .take(1)
+              .takeUntil(this.dialogRef.afterClosed())
+              .subscribe(() => {
+                this.connect();
+              });
+            break;
+          default:
+            this.snackRef.open('An unknown error occurred');
+            break;
+        }
+      },
+    );
+  }
+
+  /**
+   * Waits for the user to log in (or the dialog to close) and then tries
+   * to connect() to Interactive.
+   */
+  private login() {
+    this.state.next(State.AwaitingLogin);
+
+    const sub = Observable.interval(1000)
+      .switchMap(() => this.http.get(apiUrl('login')))
+      .takeUntil(this.dialogRef.afterClosed())
+      .map(res => res.json())
+      .subscribe(res => {
+        if (res.code) {
+          this.code.next(res.code);
+          return;
+        }
+
+        this.state.next(State.Connecting);
+        this.connect();
+        sub.unsubscribe();
+      });
+  }
+}

--- a/src/webpack/editor/nav/code-nav.component.scss
+++ b/src/webpack/editor/nav/code-nav.component.scss
@@ -10,7 +10,6 @@
   text-decoration: none;
   cursor: pointer;
   font-size: 14px;
-  font-weight: 300;
   margin: 2px $dimension-gutter-md 0;
   background: transparent;
   border-bottom: 2px solid transparent;

--- a/src/webpack/editor/nav/nav.component.html
+++ b/src/webpack/editor/nav/nav.component.html
@@ -56,7 +56,8 @@
   </button>
   <button md-icon-button
     mdTooltipPosition="below"
-    mdTooltip="Connect to Interactive">
+    mdTooltip="Connect to Interactive"
+    (click)="connect()">
     <md-icon svgIcon="rocket"></md-icon>
   </button>
 </div>

--- a/src/webpack/editor/nav/nav.component.ts
+++ b/src/webpack/editor/nav/nav.component.ts
@@ -1,8 +1,10 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MdDialog } from '@angular/material';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
 import { devices, IDevice } from '../frame/devices';
+import { LaunchDialogComponent } from '../launch-dialog/launch-dialog.component';
 import { IFrameState } from '../redux/frame';
 import { IProject, ProjectService } from '../redux/project';
 
@@ -23,7 +25,11 @@ export class NavComponent {
   public canUndo = this.store.select(s => s.history.behind.length > 0);
   public canRedo = this.store.select(s => s.history.ahead.length > 0);
 
-  constructor(private project: ProjectService, private store: Store<IProject>) {}
+  constructor(
+    private project: ProjectService,
+    private store: Store<IProject>,
+    private dialog: MdDialog,
+  ) {}
 
   public chooseDevice(index: number) {
     this.project.chooseDevice(index);
@@ -47,5 +53,11 @@ export class NavComponent {
 
   public redo() {
     this.project.redo();
+  }
+
+  public connect() {
+    this.dialog.open(LaunchDialogComponent).afterClosed().subscribe(_result => {
+      // todo(connor4312): 08/22 left off
+    });
   }
 }

--- a/src/webpack/editor/redux/connect.ts
+++ b/src/webpack/editor/redux/connect.ts
@@ -1,0 +1,59 @@
+import { IStateDump } from '../../../stdlib/mixer';
+
+/**
+ * Orientation is given to size() to determine the device orientation.
+ * Landscape is the default orientation.
+ */
+export const enum ConnectState {
+  Idle,
+  Active,
+}
+
+/**
+ * IInteractiveJoin is returned from Mixer with details for the user to use
+ * to connect to Interactive.
+ */
+export interface IInteractiveJoin {
+  address: string;
+  contentAddress: string;
+}
+
+/**
+ * IConnectState is the state describing whether the controls are connected
+ * to Mixer interactive.
+ */
+export interface IConnectState {
+  state: ConnectState;
+  /**
+   * Nested controls state.
+   */
+  controlsState?: IStateDump;
+  /**
+   * Address where Interactive lives. A subset of the response given by
+   * the Mixer backend on /api/v1/interactive/{channel}
+   */
+  join?: IInteractiveJoin;
+}
+
+export const enum Action {
+  Connect = 'CONNECT_CONNECT',
+  Disconnect = 'CONNECT_DISCONNECT',
+  UpdateState = 'CONNECT_UPDATE_STATE',
+}
+
+export const initialState = {
+  state: ConnectState.Idle,
+};
+
+export function reducer(state: IConnectState, action: any): IConnectState {
+  switch (action.type) {
+    case Action.Connect:
+      return { ...state, state: ConnectState.Active, join: action.data };
+    case Action.Disconnect:
+      return { ...state, state: ConnectState.Idle, join: undefined };
+    case Action.UpdateState:
+      return { ...state, controlsState: action.controlsState };
+    default:
+      return state;
+  }
+}

--- a/src/webpack/editor/redux/project.ts
+++ b/src/webpack/editor/redux/project.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { ActionReducer, Store } from '@ngrx/store';
 import * as patch from 'fast-json-patch';
-import { CodeState } from './code';
 
+import { IStateDump } from '../../../stdlib/mixer';
 import * as Code from './code';
+import * as Connect from './connect';
 import * as Frame from './frame';
 
 const enum Action {
@@ -34,6 +35,7 @@ export interface IProject {
   history: IHistoryState;
   frame: Frame.IFrameState;
   code: Code.ICodeState;
+  connect: Connect.IConnectState;
 }
 
 /**
@@ -95,8 +97,31 @@ export class ProjectService {
   /**
    * Updates the controls tab/state.
    */
-  public setCodeState(state: CodeState) {
+  public setCodeState(state: Code.CodeState) {
     this.store.dispatch({ type: Code.Action.SetState, state });
+  }
+
+  // Connect actions ---------------------------------------------------------
+
+  /**
+   * Updates the active controls state.
+   */
+  public connectControls(data: Connect.IInteractiveJoin) {
+    this.store.dispatch({ type: Connect.Action.Connect, data });
+  }
+
+  /**
+   * Disconnects the active interactive controls.
+   */
+  public disconnectControls() {
+    this.store.dispatch({ type: Connect.Action.Disconnect });
+  }
+
+  /**
+   * Updates the connected state.
+   */
+  public setControlsState(controlsState: IStateDump) {
+    this.store.dispatch({ type: Connect.Action.UpdateState, controlsState });
   }
 }
 
@@ -163,6 +188,7 @@ const initialState: IProject = {
   },
   frame: Frame.initialState,
   code: Code.initialState,
+  connect: Connect.initialState,
 };
 
 /**

--- a/src/webpack/editor/util/env.ts
+++ b/src/webpack/editor/util/env.ts
@@ -1,0 +1,15 @@
+import { IDevEnvironment } from '../../typings';
+
+export const dev: IDevEnvironment = (<any>window).miixDev;
+
+/**
+ * Returns a path on the local API dev server.
+ */
+export function apiUrl(path: string) {
+  if (path[0] === '/') {
+    path = path.slice(1);
+  }
+
+  // tslint:disable-next-line
+  return `http://${dev.address}/${path}`;
+}

--- a/src/webpack/typings.ts
+++ b/src/webpack/typings.ts
@@ -1,0 +1,7 @@
+/**
+ * IDevEnvironment is the environment structure stored as JSON in the
+ * devEnvironmentVar.
+ */
+export interface IDevEnvironment {
+  address: string;
+}

--- a/static/editor/declarations.scss
+++ b/static/editor/declarations.scss
@@ -20,6 +20,8 @@ $dimension-gutter-lg: 32px;
 $dimension-gutter-xl: 64px;
 
 $dimension-navbar-height: 65px;
+$dimension-loader-size: 32px;
+$dimension-loader-border: 3px;
 
 $swift-ease-out-duration: 300ms !default;
 $swift-ease-out-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;

--- a/static/editor/style.scss
+++ b/static/editor/style.scss
@@ -7,4 +7,17 @@
 body {
   background: url(asset('background.png')) #2e2e2e;
   font-family: $font-family-sans-serif;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: $color-highlight;
+  cursor: pointer;
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+
+  &:hover {
+    border-bottom-color: transparent;
+  }
 }


### PR DESCRIPTION
This is wide-ranging commit since a lot of different components have to work to
get any real "result" going. The end goal now is getting a bundle working E2E,
and as an intermediate step have the editor be able to connect to a channel
in prod today. To that end, these are the general changes:

 - Added a `pack` command to create a bundle as it will be uploaded to our serves
 - Fleshed out the dev server API to add login and connect endpoints. These
   proxy to the production endpoints for the most part, but that can be
   overridden to point at standalone
 - Added the UI for logging in and connecting in the editor.
 - WIP: a Participant class that the editor and our production frontend will use
   to actually connect to Interactive.
 - WIP: state changes in the editor to handle being connected. The idea is that
   the code editor on the side will be disabled for input but update with the
   current control state tree displayed on the RHS.

Some screen grabs posted in Slack earlier:

 - https://peet.io/i/17-08-ctl9l52qhnb2j7mql2e5zat44iik3x.mp4
 - https://peet.io/i/17-08-ptgckpcxtzxzwzmjqgprl7kg45hkxl.mp4