### PR TITLE
feat(webpack): auto-install dependencies, don't require locales to be provided

### DIFF
--- a/src/cli/commands/pack.ts
+++ b/src/cli/commands/pack.ts
@@ -3,8 +3,10 @@ import * as ora from 'ora';
 
 import { Bundler } from '../../server/publish/bundler';
 import { IGlobalOptions } from '../options';
+import { ensureWebpackDependencies } from '../prereqs';
 
 export default async function(options: IGlobalOptions): Promise<void> {
+  await ensureWebpackDependencies(options.project);
   const spinner = ora('Starting...').start();
   const output = await new Bundler(options.project).bundle(progress => {
     spinner.text = progress;

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -6,6 +6,7 @@ import { Publisher } from '../../server/publish/publisher';
 import { Uploader } from '../../server/publish/uploader';
 import { Fetcher } from '../../server/util';
 import { failSpiner, IGlobalOptions } from '../options';
+import { ensureWebpackDependencies } from '../prereqs';
 import writer from '../writer';
 
 export interface IPublishOptions extends IGlobalOptions {
@@ -32,6 +33,7 @@ export default async function(options: IPublishOptions): Promise<void> {
   }
 
   if (!options.skipBundle) {
+    await ensureWebpackDependencies(options.project);
     let filename = options.tarball;
     if (!filename) {
       const output = await bundler

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -7,6 +7,7 @@ import { never } from '../../server/util';
 import { IDevEnvironment } from '../../ui/typings';
 import { devEnvironmentVar } from '../../webpack-plugin';
 import { IGlobalOptions } from '../options';
+import { ensureWebpackDependencies } from '../prereqs';
 
 const portfinder = require('portfinder');
 portfinder.basePort = 13370;
@@ -24,6 +25,8 @@ function defaultArgs(original: string[], defaults: { [key: string]: string | boo
 }
 
 export default async function(options: IGlobalOptions): Promise<void> {
+  await ensureWebpackDependencies(options.project);
+
   const argDelimiter = process.argv.indexOf('--');
   const port = await portfinder.getPortPromise();
   const server = createServer(createApp(options.project)).listen(port);

--- a/src/cli/commands/upload.ts
+++ b/src/cli/commands/upload.ts
@@ -5,6 +5,7 @@ import { Bundler } from '../../server/publish/bundler';
 import { Uploader } from '../../server/publish/uploader';
 import { Fetcher } from '../../server/util';
 import { failSpiner, IGlobalOptions } from '../options';
+import { ensureWebpackDependencies } from '../prereqs';
 import writer from '../writer';
 
 export interface IUploadOptions extends IGlobalOptions {
@@ -12,6 +13,7 @@ export interface IUploadOptions extends IGlobalOptions {
 }
 
 export default async function(options: IUploadOptions): Promise<void> {
+  await ensureWebpackDependencies(options.project);
   const fetcher = new Fetcher().with(await options.project.profile.tokens());
   const bundler = new Bundler(options.project);
 

--- a/src/cli/prereqs.ts
+++ b/src/cli/prereqs.ts
@@ -1,0 +1,56 @@
+import chalk from 'chalk';
+
+import { ChildProcess, spawn } from 'child_process';
+import { isPackagedInstalled } from '../server/npm';
+import { Project } from '../server/project';
+import { awaitChildProcess } from '../server/util';
+import writer from './writer';
+
+async function ensurePackagesInstalled(project: Project, ...reqs: string[]): Promise<void> {
+  if (await isPackagedInstalled(project.baseDir(), ...reqs)) {
+    return;
+  }
+
+  let config: any;
+  try {
+    config = await project.packageJson();
+  } catch (e) {
+    writer.write("We couldn't read the package.json in your project directory:");
+    throw e;
+  }
+
+  const doInstall = await writer.confirm(
+    'To do this, we first need to install some dependencies. This may take a minute or two.',
+  );
+
+  if (!doInstall) {
+    writer.write(chalk.red('Installation aborted'));
+    process.exit(0);
+  }
+
+  const areAllRequired = !reqs.some(r => {
+    const isRequired =
+      (config.dependencies && config.dependencies[r]) ||
+      (config.devDependencies && config.devDependencies[r]);
+    return !isRequired;
+  });
+
+  writer.write('Installing packages:', reqs);
+
+  let proc: ChildProcess;
+  if (areAllRequired) {
+    proc = spawn('npm', ['install'], { cwd: project.baseDir() });
+  } else {
+    proc = spawn('npm', ['install', '--save-dev'].concat(reqs), { cwd: project.baseDir() });
+  }
+
+  return awaitChildProcess(proc);
+}
+
+/**
+ * Ensures that webpack and the webpack-dev-server are installed in the
+ * target directory, installing them if they aren't.
+ */
+export async function ensureWebpackDependencies(project: Project): Promise<void> {
+  return ensurePackagesInstalled(project, 'webpack', 'webpack-dev-server');
+}

--- a/src/server/metadata/metadata.ts
+++ b/src/server/metadata/metadata.ts
@@ -3,6 +3,12 @@ import * as Joi from 'joi';
 import { IPackageConfig } from '@mcph/miix-std/dist/internal';
 import { MetadataExtractor } from './extractor';
 
+export interface IBundleConfig extends IPackageConfig {
+  toolchain?: {
+    kind: string;
+  };
+}
+
 const inputSchema = Joi.object({
   propertyName: Joi.string().required(),
   alias: Joi.string().required(),

--- a/src/server/npm.ts
+++ b/src/server/npm.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { existsSync } from 'fs';
 import { readDir } from './util';
 
 /**
@@ -87,4 +88,12 @@ export async function findReadme(dir: string): Promise<string | undefined> {
   } catch (e) {
     return undefined;
   }
+}
+
+/**
+ * Returns whether all requested dependencies are installed in node_modules
+ * relative to the project base directory.
+ */
+export async function isPackagedInstalled(baseDir: string, ...dependencies: string[]) {
+  return !dependencies.some(dep => !existsSync(path.join(baseDir, 'node_modules', dep)));
 }

--- a/src/webpack-plugin.ts
+++ b/src/webpack-plugin.ts
@@ -178,6 +178,10 @@ class LocalePackager {
    * (from the file basenames) to their contents.
    */
   public async compile(pattern: string): Promise<{ [locale: string]: object }> {
+    if (!pattern) {
+      return {};
+    }
+
     const files = glob.sync(pattern);
     const output: { [locale: string]: object } = {};
 


### PR DESCRIPTION
 - Prompts the user to install missing things if they're missing, instead of failing cryptically:

![](https://peet.io/i/17-12-ixe0ufmu5cwjftds17qs7pbeaehs8z.png)

- Don't fail if locales are not provided, as they are not in the new [html starter project](https://github.com/mixer/interactive-html-starter)