### PR TITLE
Child process NPM install fails on Windows

### DIFF
--- a/bin/miix
+++ b/bin/miix
@@ -159,7 +159,7 @@ const yargs = require('yargs')
         })
         .option('npm', {
           description: 'npm path to use when installing the quickstart dependencies',
-          default: 'npm',
+          default: /^win/.test(process.platform) ? 'npm.cmd' : 'npm',
         })
         .demand('projectName'),
     execute


### PR DESCRIPTION
On Windows, the child process that npm installs fails because 'npm' cannot be found.

For Windows, the npm path must be 'npm.cmd'.