### PR TITLE
chore(cli): Use Azure instead of GitHub

### DIFF
--- a/src/cli/commands/quickstart.ts
+++ b/src/cli/commands/quickstart.ts
@@ -10,7 +10,7 @@ import { UnexpectedHttpError } from '../../server/errors';
 import { awaitChildProcess, readFile, writeFile } from '../../server/util';
 import writer from '../writer';
 
-const launchpadUrl = 'https://github.com/mixer/interactive-launchpad/archive/master.tar.gz';
+const launchpadUrl = 'https://mixercc.azureedge.net/launchpad/interactive-launchpad_0.2.0.tar.gz';
 
 export interface IQuickStartOptions {
   dir: string;


### PR DESCRIPTION
Changed the launchpad url to pull from azure instead of github.